### PR TITLE
Support for titleAttr as an optional reference

### DIFF
--- a/src/calendar/calendar.xml
+++ b/src/calendar/calendar.xml
@@ -65,7 +65,7 @@
 				<attributeType name="DateTime"/>
 			</attributeTypes>
 		</property>
-        <property key="titleAttr" type="attribute" entityProperty="eventEntity">
+        <property key="titleAttr" type="attribute" isPath="optional" pathType="reference" entityProperty="eventEntity">
 			<caption>Title</caption>
 			<category>Event data</category>
 			<description></description>
@@ -265,6 +265,16 @@
 				<enumerationValue key="agendaDay">Agenda day</enumerationValue>
 			</enumerationValues> 
 		</property>
+		<property key="axisFormat" type="string" defaultValue="h(:mm)tt">
+			<caption>Agenda axis time format</caption>
+			<category>Extra</category>
+			<description>The format of the vertical axis labels in agenda views (default h(:mm)tt)</description>
+		</property>
+		<property key="slotMinutes" type="integer" defaultValue="30">
+			<caption>Slot duration</caption>
+			<category>Extra</category>
+			<description>The time interval (in minutes) of day and week calendars. (Default: 30)</description>
+		</property>
 		<property key="notused1" type="object" isList="true" required="false">
             <caption>Available views</caption>
             <category>Extra</category>
@@ -302,8 +312,8 @@
 					<category>Extra</category>
 					<description>The label used for the button.</description>
 				</property>
-            </properties>
-        </property>	
+			</properties>
+		</property>
 <!--	This has become obsolete:
 		<property key="listenchannel" type="string" required="false">
             <caption>Listen source</caption>


### PR DESCRIPTION
I have added support for making a tittleAttr an optional reference or a
simple attribute.  This is primarily done by adding a prepareEvents
method "in front of" the createEvents method that does a
mx.processor.get() to pull in any referred attributes.  All of these changes are in the file calendar.js.

Note: I have also added two minor features that are supported by the
underlying fullcalendar.js, but not currently  supported in the Mendix
Calendar widget.

The first is to support the axisFormat property that controls the time
labels along the left side of day and agenda views.  In particular, this
needs to be adjusted to HH:mm if one prefers to use a 24-hour clock
instead of the default hh(:mm)tt format string.

Second, I have exposed the slotMinutes property that allows the time
increment of day and agenda calenders to be altered from the default of
30 minutes.  For example, in a law office, one might want to support
time increments of either 10 or 15 minutes for billing purposes.
Reserving tennis courts using the Calendar widget might wish to have a
minimum calendar increment of 60 minutes.

These last two enhancements required minor changes to both calendar.xml and to calendar.js.
Note: in this version, I have added the axisFormat and slotMinutes as settable properties on the "Extra" tab of the properties file.

These changes were added to the most recent tagged version (2.3.1, I believe) of the repository.

As this is my first significant attempt to contribute to a GitHub widget, I apologize if I have misunderstood the ground rules of how I should try to contribute.  I can be reached directly at shott@stanford.edu if I have not done this properly.

Thank you,

John
