### PR TITLE
Added axisFormat

### DIFF
--- a/src/calendar/calendar.xml
+++ b/src/calendar/calendar.xml
@@ -233,7 +233,7 @@
 		<property key="axisFormat" type="translatableString" required="false">
 			<caption>Agenda axis time format</caption>
 			<category>Extra</category>
-			<description>The format of the vertical axis labels in agenda views. Default: h(:mm)tt</description>
+			<description>The format of the vertical axis labels in agenda views. Default: h(:mm)a</description>
 		</property>
 		<property key="slotMinutes" type="string" defaultValue="00:30:00">
 			<caption>Slot duration</caption>

--- a/src/calendar/calendar.xml
+++ b/src/calendar/calendar.xml
@@ -230,6 +230,11 @@
 				<enumerationValue key="agendaDay">Agenda day</enumerationValue>
 			</enumerationValues>
 		</property>
+		<property key="axisFormat" type="translatableString" required="false">
+			<caption>Agenda axis time format</caption>
+			<category>Extra</category>
+			<description>The format of the vertical axis labels in agenda views. Default: h(:mm)tt</description>
+		</property>
 		<property key="slotMinutes" type="string" defaultValue="00:30:00">
 			<caption>Slot duration</caption>
 			<category>Extra</category>

--- a/src/calendar/widget/calendar.js
+++ b/src/calendar/widget/calendar.js
@@ -487,7 +487,7 @@ require({
 			this.dayNamesFormat = this.dayNamesFormat ? this.dayNamesFormat.split(",") : null;
 			this.dayShortNamesFormat = this.dayShortNamesFormat ? this.dayShortNamesFormat.split(",") : null;
 			this.slotMinutes = this.slotMinutes ? this.slotMinutes : '00:30:00';
-			this.axisFormat = this.axisFormat ? this.axisFormat : 'h(:mm)a'
+			this.axisFormat = this.axisFormat ? this.axisFormat : 'h(:mm)a';
 			this.startTime = this.startTime ? this.startTime : '08:00';
 			this.endTime = this.endTime ? this.endTime : '17:00';
 

--- a/src/calendar/widget/calendar.js
+++ b/src/calendar/widget/calendar.js
@@ -487,6 +487,7 @@ require({
 			this.dayNamesFormat = this.dayNamesFormat ? this.dayNamesFormat.split(",") : null;
 			this.dayShortNamesFormat = this.dayShortNamesFormat ? this.dayShortNamesFormat.split(",") : null;
 			this.slotMinutes = this.slotMinutes ? this.slotMinutes : '00:30:00';
+			this.axisFormat = this.axisFormat ? this.axisFormat : 'h(:mm)tt'
 			this.startTime = this.startTime ? this.startTime : '08:00';
 			this.endTime = this.endTime ? this.endTime : '17:00';
 
@@ -517,6 +518,7 @@ require({
 				weekNumberTitle: this.weeknumberTitle,
 				weekends: this.showWeekends,
 				slotDuration: this.slotMinutes,
+				axisFormat: this.axisFormat,
 				buttonText: this._buttonText,
 				lang: this.languageSetting,
 				eventLimit: this.limitEvents

--- a/src/calendar/widget/calendar.js
+++ b/src/calendar/widget/calendar.js
@@ -487,7 +487,7 @@ require({
 			this.dayNamesFormat = this.dayNamesFormat ? this.dayNamesFormat.split(",") : null;
 			this.dayShortNamesFormat = this.dayShortNamesFormat ? this.dayShortNamesFormat.split(",") : null;
 			this.slotMinutes = this.slotMinutes ? this.slotMinutes : '00:30:00';
-			this.axisFormat = this.axisFormat ? this.axisFormat : 'h(:mm)tt'
+			this.axisFormat = this.axisFormat ? this.axisFormat : 'h(:mm)a'
 			this.startTime = this.startTime ? this.startTime : '08:00';
 			this.endTime = this.endTime ? this.endTime : '17:00';
 


### PR DESCRIPTION
I have done my best to add back in the axisFormat property.  This defines the formatting of the left time axis on the agenda week and agenda day  views.  While the default format is h(:mm)a, most European users will want to define it to be something such as HH(:mm) to display times in 24-hour format.

I have tested this in my local Mendix environment, but do not know how to do more extensive testing.

Thanks,

John
