### PR TITLE
Added 'four weeks' calendar view

### DIFF
--- a/src/calendar/calendar.xml
+++ b/src/calendar/calendar.xml
@@ -246,6 +246,7 @@
 			<description>Which is the default view when the widget is loaded</description>
 			<enumerationValues>
 				<enumerationValue key="month">Month</enumerationValue>
+				<enumerationValue key="fourWeeks">Four weeks</enumerationValue>
 				<enumerationValue key="basicWeek">Basic week</enumerationValue>
 				<enumerationValue key="basicDay">Basic day</enumerationValue>
 				<enumerationValue key="agendaWeek">Agenda week</enumerationValue>

--- a/src/calendar/calendar.xml
+++ b/src/calendar/calendar.xml
@@ -304,6 +304,7 @@
 					<description></description>
 					<enumerationValues>
 						<enumerationValue key="month">Month</enumerationValue>
+						<enumerationValue key="fourWeeks">Four weeks</enumerationValue>
 						<enumerationValue key="basicWeek">Basic week</enumerationValue>
 						<enumerationValue key="basicDay">Basic day</enumerationValue>
 						<enumerationValue key="agendaWeek">Agenda week</enumerationValue>

--- a/src/calendar/lib/fullcalendar.js
+++ b/src/calendar/lib/fullcalendar.js
@@ -11993,6 +11993,11 @@
     	duration: { weeks: 1 }
     };
 
+    fcViews.fourWeeks = {
+    	'class': MonthView,
+    	duration: { weeks: 4 } // important for prev/next
+    };
+
     fcViews.month = {
     	'class': MonthView,
     	duration: { months: 1 }, // important for prev/next


### PR DESCRIPTION
We needed an additional calendar view for one of our customers, similar to the month view, but containing four weeks. I've adjusted the widget, but it might be a nice addition for a next release of the widget.